### PR TITLE
User Can View a Single Task

### DIFF
--- a/DjangoTaskManager/account/views.py
+++ b/DjangoTaskManager/account/views.py
@@ -32,6 +32,15 @@ def account_login(request):
 
 @login_required
 def account_logout(request):
+    """
+    Purpose: Handles logging the user out from the system
+
+    Author: max Baldridge
+
+    Arguments: request -- the full hTTP response object
+
+    Returns: n/a
+    """
     # Since we know the user is logged in, we can now just log them out.
     logout(request)
     # Take the user back to the login.

--- a/DjangoTaskManager/task/urls.py
+++ b/DjangoTaskManager/task/urls.py
@@ -5,7 +5,12 @@ from DjangoTaskManager.task import views
 urlpatterns = [
     url(r'^$', views.all_tasks, name='all_tasks'),
     url(r'^add/$', views.add, name='task_add'),
-    url(r'^mark-done/(?P<task_id>[\w+:-]+)/$', views.mark_done, name='task_mark_done'),
-    url(r'^edit/(?P<task_id>[\w+:-]+)/$', views.edit, name='task_edit'),
-    url(r'^delete/(?P<task_id>[\w+:-]+)/$', views.delete, name='task_delete'),
+    url(r'^mark-done/(?P<task_id>[\w+:-]+)/$',
+        views.mark_done, name='task_mark_done'),
+    url(r'^edit/(?P<task_id>[\w+:-]+)/$',
+        views.edit, name='task_edit'),
+    url(r'^delete/(?P<task_id>[\w+:-]+)/$',
+        views.delete, name='task_delete'),
+    url(r'^single/(?P<task_id>[\w+:-]+)/$',
+        views.single, name='single_task'),
 ]

--- a/DjangoTaskManager/task/views.py
+++ b/DjangoTaskManager/task/views.py
@@ -1,5 +1,7 @@
 from django.contrib.auth.decorators import login_required
 from django.http import Http404, HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.shortcuts import render
 from django.template.response import TemplateResponse
 from django.urls import reverse
 
@@ -17,7 +19,7 @@ def all_tasks(request):
 
     Arguments: Request -- the full HTTP request object
 
-    Returns: all tasks created by all registered users
+    Returns: (TemplateResponse): all tasks created by all registered users
     """
     hide_completed = request.GET.get('hide_completed', False)
     tasks = Task.objects.all()
@@ -32,13 +34,15 @@ def all_tasks(request):
 @login_required
 def add(request):
     """
-    Purpose: to present the user with a form to upload information about a task to complete
+    Purpose: to present the user with a form
+    to upload information about a task to complete
 
     Author: Max Baldridge
 
     Arguments: Request -- the full HTTP request object
 
-    Returns: (TemplateResponse): A form that lets the user upload a a task to complete
+    Returns:
+        (TemplateResponse): Form that lets the user upload a a task to complete
     """
     if request.method == 'POST':
         form = AddTaskForm(request.POST)
@@ -51,7 +55,8 @@ def add(request):
             ).save()
             return HttpResponseRedirect(reverse('all_tasks'))
         else:
-            return TemplateResponse(request, 'edit_task.html', {'errors': form.errors})
+            return TemplateResponse(
+                request, 'edit_task.html', {'errors': form.errors})
     else:
         return TemplateResponse(request, 'edit_task.html', {})
 
@@ -59,20 +64,20 @@ def add(request):
 @login_required
 def mark_done(request, task_id):
     """
-     Purpose: Allows user to mark a task as completed, whether editing it,
-     or viewing it in the complete list of tasks.
-     Checks to see if a specific task id appears, 
-     and if it does to complete the task.
-     If no id is found for the task, the raises a 404 [not found] error
+    Purpose: Allows user to mark a task as completed, whether editing it,
+    or viewing it in the complete list of tasks.
+    Checks to see if a specific task id appears,
+    and if it does to complete the task.
+    If no id is found for the task, the raises a 404 [not found] error
 
-     Author: Max Baldridge
+    Author: Max Baldridge
 
-     Arguments: Request -- the full HTTP request object
+    Arguments:  Request -- the full HTTP request object
                 task_id: (integer): id of task we are marking as complete
 
-     Returns: (HttpResponseRedirect):
-        the view of all tasks, with the current task as all
-     """
+    Returns: 
+        (HttpResponseRedirect): the view of all tasks, with the current task as all
+    """
     try:
         task = Task.objects.get(id=task_id)
         task.completed = True
@@ -86,20 +91,21 @@ def mark_done(request, task_id):
 @login_required
 def edit(request, task_id):
     """
-     Purpose: Allows user to view the edit view, 
-     which contains a very specific view
-     for editing a singular task
-     For an example, visit /edit/1/ to see a view on the first task created
-     displaying title, description, assignee, 
-     and whether or not it's been completed. 
+    Purpose: Allows user to view the edit view,
+    which contains a very specific view
+    for editing a singular task
+    For an example, visit /edit/1/ to see a view on the first task created
+    displaying title, description, assignee,
+    and whether or not it's been completed.
 
-     Author: Max Baldridge 
+    Author: Max Baldridge
 
-     Arguments: Request -- the full HTTP request object
-                task_id: (integer): id of task we are editing
+    Arguments: Request -- the full HTTP request object
+            task_id: (integer): id of task we are editing
 
-     Returns: (render): a view of the request, template to use, and product obj
-     """
+    Returns: 
+        (TemplateResponse): a view of the request, template to use, and task obj
+    """
     if request.method == 'POST':
         form = EditTaskForm(
             instance=Task.objects.get(id=task_id),
@@ -124,22 +130,40 @@ def edit(request, task_id):
             'edit_task.html',
             {'form': form,
                 'edit': True,
-                'task_id':task_id})
+                'task_id': task_id})
+
+
+@login_required
+def single(request, task_id):
+    """
+    Purpose: Allows user to view the single_task view,
+    which contains a specific view for. singular task
+
+    Author: Max Baldridge
+
+    Arguments:  Request-- the full HTTP request object
+                task_id: (integer): id of the task being viewed
+
+    Returns: (render): a view of the
+    """
+    template_name = 'single.html'
+    task = get_object_or_404(Task, pk=task_id)
+    return render(request, template_name, {'task': task})
 
 
 @login_required
 def delete(request, task_id):
     """
-     Purpose: Allows user to delete a single task,
-     thus removing it from the list of all user tasks.
+    Purpose: Allows user to delete a single task,
+    thus removing it from the list of all user tasks.
 
-     Author: Max Baldridge
+    Author: Max Baldridge
 
-     Arguments: Request -- the full HTTP request object
+    Arguments:  Request -- the full HTTP request object
                 task_id: (integer): id of task we are removing
 
-     Returns: (render): a view of the request, template to use, and product obj
-     """
+    Returns: (TemplateResponse): a view of the request, template to use, and product obj
+    """
     try:
         Task.objects.get(id=task_id).delete()
     except Task.DoesNotExist:

--- a/DjangoTaskManager/templates/base.html
+++ b/DjangoTaskManager/templates/base.html
@@ -1,8 +1,9 @@
 <html lang="en">
     <head>
-        <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta charset="utf-8">
         <title>{% block title %}{% endblock %}|Task Manager</title>
+        <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     </head>
     <body>
         <div class="container" style="margin-top: 10px">
@@ -11,7 +12,7 @@
                 <a class="btn btn-default pull-right" href="{% url "logout" %}">Logout</a>
             {% endif %}
             <h1><u>Task Manager</u></h1>
-        {% block content %}{% endblock %}
+            {% block content %}{% endblock %}
         </div>
     </body>
 </html>

--- a/DjangoTaskManager/templates/base.html
+++ b/DjangoTaskManager/templates/base.html
@@ -2,7 +2,7 @@
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta charset="utf-8">
-        <title>{% block title %}{% endblock %}|Task Manager</title>
+        <title>{% block title %}{% endblock %}|DjangoTaskManager</title>
         <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     </head>
     <body>
@@ -11,7 +11,7 @@
                 <a class="btn btn-default pull-center" href="{% url "tasks" %}">Home</a>
                 <a class="btn btn-default pull-right" href="{% url "logout" %}">Logout</a>
             {% endif %}
-            <h1><u>Task Manager</u></h1>
+            <h1><u>DjangoTaskManager</u></h1>
             {% block content %}{% endblock %}
         </div>
     </body>

--- a/DjangoTaskManager/templates/single.html
+++ b/DjangoTaskManager/templates/single.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block title %}Single Task{% endblock %}
+
+{% block content %}
+<br>
+<div style="margin: 10px">
+	<dl style="font-size: 18px">
+		<dt>Title: </dt>
+			<dd>{{ task.name }}</dd>
+		<br>
+	    <dt>Description: </dt>
+	    	<dd>{{ task.description }}</dd>
+	    <br>
+	    <dt>Created by: </dt>
+	    	<dd>{{ task.created_by.username }}</dd>
+	    <br>
+	    <dt>Assigned to: </dt>
+	    	<dd>{{ task.assignee.username }}</dd>
+	    <br>
+	    <dt>Date Assigned: </dt>
+	    	<dd>{{ task.created }}</dd>
+	    <br>
+	    </li>
+	    {% if not task.completed %}
+	    <dt>
+		        <a class="btn btn-success" href="{% url "task_mark_done" task.id %}">Mark Done</a>
+		</dt>
+		{% endif %}
+	</dl>
+{% endblock %}

--- a/DjangoTaskManager/templates/tasks.html
+++ b/DjangoTaskManager/templates/tasks.html
@@ -32,15 +32,23 @@
                         {% else %}
                             <tr>
                         {% endif %}
-                            <td class="text-center">{{ task.name }}</td>
-                            <td class="text-center">{{ task.assignee.username }}</td>
-                            <td class="text-center">{{ task.created_by.username }}</td>
-                            <td class="text-center">{{ task.created }}</td>
+                            <td class="text-center">
+                                <a href="{% url "single_task" task.id %}">{{ task.name }}</a>
+                            </td>
+                            <td class="text-center">
+                                {{ task.assignee.username }}
+                            </td>
+                            <td class="text-center">
+                                {{ task.created_by.username }}
+                            </td>
+                            <td class="text-center">
+                                {{ task.created }}
+                            </td>
                             <td class="text-center">
                                 {% if not task.completed %}
                                     <a class="btn btn-success" href="{% url "task_mark_done" task.id %}">Mark Done</a>
                                 {% endif %}
-                                <a class="btn btn-default" href="{% url "task_edit" task.id %}">Edit</a>
+                                    <a class="btn btn-default" href="{% url "task_edit" task.id %}">Edit</a>
                                 {% if not task.deleted %}
                                     <a class="btn btn-danger" href="{% url "task_delete" task.id %}">Delete</a>
                                 {% endif %}


### PR DESCRIPTION
# DjangoTaskManager Pull Request Template

## Status
Is this PR ready to be looked at by other group members? 
Yes

## Description
This feature now allows the user to view a single task and its various descriptive features. As well as marking it as done on the single task views.

## Related Tickets 
List all related tickets that are addressed by this pull request

[#7](https://github.com/MaxwellCoriell/DjangoTaskManager/issues/7)

## Impacted Areas of the Application
Files that this PR modifies or affects in some way. 
```
    DjangoTaskManager/templates/base.html
    DjangoTaskManager/templates/single.html
    DjangoTaskManager/task/views.py
    DjangoTaskManager/task/urls.py
```

## Deploy Notes
Anything that a user needs to know in order to deploy/properly test this branch. Provide step by step instructions that address any db migrations, packages needed, ect. Be as specific as possible in your instructions

For example: 
```
    git checkout master
    git pull origin master
    git fetch --all
    git checkout mx-ViewSingleTask-1
    cd DjangoTaskManager/DjangoTaskManager
    ./migrate_Django.sh 
    python manage.py runserver
```

1. Register a user
2. Create a task
3. View the base page and gesture on the task name
4. View that super awesome single task
5. Mark it as being done if you want.